### PR TITLE
feat: Add an actor to test proxy access

### DIFF
--- a/proxy-access/.actor/Dockerfile
+++ b/proxy-access/.actor/Dockerfile
@@ -1,0 +1,30 @@
+# Specify the base Docker image. You can read more about
+# the available images at https://sdk.apify.com/docs/guides/docker-images
+# You can also use any other image from Docker Hub.
+FROM apify/actor-node:16
+
+# Copy just package.json and package-lock.json
+# to speed up the build using Docker layer cache.
+COPY package*.json ./
+
+# Install NPM packages, skip optional and development dependencies to
+# keep the image small. Avoid logging too much and print the dependency
+# tree for debugging
+RUN npm --quiet set progress=false \
+    && npm install --omit=dev --omit=optional \
+    && echo "Installed NPM packages:" \
+    && (npm list --omit=dev --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version \
+    && rm -r ~/.npm
+
+# Next, copy the remaining files and directories with the source code.
+# Since we do this after NPM install, quick build will be really fast
+# for most source file changes.
+COPY . ./
+
+
+# Run the image.
+CMD npm start --silent

--- a/proxy-access/.actor/actor.json
+++ b/proxy-access/.actor/actor.json
@@ -1,0 +1,7 @@
+{
+	"actorSpecification": 1,
+	"name": "proxy-access",
+	"version": "0.0",
+	"buildTag": "latest",
+	"environmentVariables": {}
+}

--- a/proxy-access/.dockerignore
+++ b/proxy-access/.dockerignore
@@ -1,0 +1,13 @@
+# configurations
+.idea
+
+# crawlee and apify storage folders
+apify_storage
+crawlee_storage
+storage
+
+# installed files
+node_modules
+
+# git folder
+.git

--- a/proxy-access/.editorconfig
+++ b/proxy-access/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/proxy-access/.eslintrc
+++ b/proxy-access/.eslintrc
@@ -1,0 +1,4 @@
+{
+    "extends": "@apify",
+    "root": true
+}

--- a/proxy-access/.gitignore
+++ b/proxy-access/.gitignore
@@ -1,0 +1,8 @@
+# This file tells Git which files shouldn't be added to source control
+
+.DS_Store
+.idea
+node_modules
+storage
+
+storage

--- a/proxy-access/main.js
+++ b/proxy-access/main.js
@@ -1,0 +1,40 @@
+import { Actor } from 'apify';
+import { load } from 'cheerio';
+import { gotScraping } from 'got-scraping';
+import { sleep } from '@crawler/utils';
+
+// This is an actor that checks if the proxy access is working.
+// It opens a http://proxy.apify.com/ and checks if the status is "connected".
+
+await Actor.init();
+
+const CONNECTED_STATUS = 'connected';
+
+const proxyConfig = await Actor.createProxyConfiguration({});
+
+let response;
+let lastError;
+
+// Requests via proxy can fail, so we retry them.
+for (let i = 0; i < 3; i++) {
+    try {
+        response = await gotScraping({
+            proxyUrl: await proxyConfig.newUrl(),
+            url: 'http://proxy.apify.com/',
+        });
+        break;
+    } catch (e) {
+        lastError = e;
+        await sleep(1000 * (2 ** i));
+    }
+}
+
+if (!response && lastError) throw lastError;
+
+const $ = await load(response.body);
+const status = await $('.status').text().toLowerCase();
+
+await Actor.setValue('OUTPUT', { status });
+
+// Exit successfully
+await Actor.exit(status === CONNECTED_STATUS ? 0 : 1);

--- a/proxy-access/package.json
+++ b/proxy-access/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "proxy-access",
+	"version": "0.0.1",
+	"type": "module",
+	"description": "This is a boilerplate of an Apify actor.",
+	"engines": {
+		"node": ">=16.0.0"
+	},
+	"dependencies": {
+		"apify": "^3.0.0",
+		"cheerio": "^1.0.0-rc.12",
+		"crawlee": "^3.0.0",
+		"got-scraping": "^3.2.12"
+	},
+	"devDependencies": {
+		"@apify/eslint-config": "^0.3.1",
+		"eslint": "^8.20.0"
+	},
+	"scripts": {
+		"start": "node main.js",
+		"lint": "./node_modules/.bin/eslint ./src --ext .js,.jsx",
+		"lint:fix": "./node_modules/.bin/eslint ./src --ext .js,.jsx --fix",
+		"test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1"
+	},
+	"author": "It's not you it's me",
+	"license": "ISC"
+}


### PR DESCRIPTION
This adds an actor to test if user has access to our proxy. It just tries to get content of `http://proxy.apify.com/` and checks if status there is `connected`. It exits wit error code if status is different. The integration tests in the app will call this actor and check if it finishes successfully.

Used for [#8910](https://github.com/apify/apify-core/issues/8910)